### PR TITLE
Have Dependabot group all updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,8 +4,16 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      ci-dependencies:
+          patterns:
+            - "*"
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      js-dependencies:
+          patterns:
+            - "*"


### PR DESCRIPTION
Group all the updates because having a list of PRs is annoying.