### PR TITLE
Refine projects grid layout

### DIFF
--- a/src/components/blog/FeaturedPosts.astro
+++ b/src/components/blog/FeaturedPosts.astro
@@ -24,21 +24,12 @@ const leadImage = leadPost ? await findImage(leadPost.image) : undefined;
             <div class="flex flex-wrap items-center gap-x-3 gap-y-2 text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-slate-500">
               <span class="text-sky-200">Featured analysis</span>
               {leadPost.category && (
-                <>
-                  <span aria-hidden="true" class="h-1 w-1 rounded-full bg-slate-600" />
-                  <a class="transition hover:text-slate-300" href={getPermalink(leadPost.category.slug, 'category')}>
-                    {leadPost.category.title}
-                  </a>
-                </>
+                <a class="transition hover:text-slate-300" href={getPermalink(leadPost.category.slug, 'category')}>
+                  {leadPost.category.title}
+                </a>
               )}
-              <span aria-hidden="true" class="h-1 w-1 rounded-full bg-slate-600" />
               <time datetime={String(leadPost.publishDate)}>{getFormattedDate(leadPost.publishDate)}</time>
-              {leadPost.readingTime && (
-                <>
-                  <span aria-hidden="true" class="h-1 w-1 rounded-full bg-slate-600" />
-                  <span>{leadPost.readingTime} min read</span>
-                </>
-              )}
+              {leadPost.readingTime && <span>{leadPost.readingTime} min read</span>}
             </div>
             <h2 class="mt-4 text-2xl font-semibold tracking-[-0.04em] text-white sm:text-[2rem]">
               <a class="transition group-hover:text-slate-50" href={getPermalink(leadPost.permalink, 'post')}>
@@ -110,12 +101,7 @@ const leadImage = leadPost ? await findImage(leadPost.image) : undefined;
                     <p class="mt-3 text-sm leading-7 text-slate-400">{post.excerpt}</p>
                     <div class="mt-4 flex flex-wrap items-center gap-x-3 gap-y-2 text-sm text-slate-500">
                       <span>{getFormattedDate(post.publishDate)}</span>
-                      {post.readingTime && (
-                        <>
-                          <span aria-hidden="true" class="h-1 w-1 rounded-full bg-slate-600" />
-                          <span>{post.readingTime} min read</span>
-                        </>
-                      )}
+                      {post.readingTime && <span>{post.readingTime} min read</span>}
                     </div>
                   </div>
                 </a>

--- a/src/components/site/TwoColumnGrid.astro
+++ b/src/components/site/TwoColumnGrid.astro
@@ -1,0 +1,13 @@
+---
+import { twMerge } from 'tailwind-merge';
+
+export interface Props {
+  class?: string;
+}
+
+const { class: className = '' } = Astro.props;
+---
+
+<div class={twMerge('grid gap-4 md:grid-cols-2 lg:gap-5', className)}>
+  <slot />
+</div>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -3,6 +3,7 @@ import { Icon } from 'astro-icon/components';
 import Layout from '~/layouts/PageLayout.astro';
 import Button from '~/components/ui/Button.astro';
 import SectionHeading from '~/components/site/SectionHeading.astro';
+import TwoColumnGrid from '~/components/site/TwoColumnGrid.astro';
 
 const metadata = {
   title: 'Projects',
@@ -122,12 +123,13 @@ const adjacentTools = [
   </section>
 
   <section class="mx-auto max-w-7xl px-4 py-18 sm:px-6 md:py-24">
-    <div class="grid gap-10 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)] lg:items-start">
+    <div>
       <SectionHeading
         title="A distributed computing approach to package ecosystem threat detection."
         description="Each Dragonfly component supports one stage of the workflow, but the value comes from how release intake, scanning, reporting, and operator review connect."
+        align="center"
       />
-      <div class="grid gap-4">
+      <TwoColumnGrid class="mt-12 lg:items-start">
         {
           projects.map((project) => (
             <div class="rounded-[1.75rem] border border-white/10 bg-[var(--vipyr-bg-panel)] p-6 shadow-[var(--vipyr-shadow)]">
@@ -152,7 +154,7 @@ const adjacentTools = [
             </div>
           ))
         }
-      </div>
+      </TwoColumnGrid>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- center the projects section heading and switch the project card list to a reusable two-column grid helper
- add `TwoColumnGrid` as a small site-level layout primitive for repeated two-column card sections
- simplify featured research metadata separators so the archive cards read more cleanly

## Validation
- npm run check
- npm run build
